### PR TITLE
Replace fetching many items or boxes, with an annotated file class

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -1,8 +1,5 @@
 from .fetcher import Fetcher
-from src.model.file import File
-from src.model.item import Item
-from src.model.box import Box
-from src.model.link import Link
+from src.model.file import File, AnnotatedFile
 
 class API:
     def __init__(self, fetcher: Fetcher):
@@ -10,11 +7,5 @@ class API:
     def get_all_files(self) -> list[File]:
         return self.fetcher.get_all_files()
 
-    def get_all_items(self) -> list[Item]:
-        return self.fetcher.get_all_items()
-
-    def get_all_boxes(self) -> list[Box]:
-        return self.fetcher.get_all_boxes()
-
-    def get_all_links(self) -> list[Link]:
-        return self.fetcher.get_all_links()
+    def get_file(self, filename: str) -> AnnotatedFile:
+        return self.fetcher.get_file(filename)

--- a/src/api/fetcher.py
+++ b/src/api/fetcher.py
@@ -1,5 +1,6 @@
+import itertools
 from src.db.db import DB
-from src.model.file import File
+from src.model.file import File, AnnotatedFile
 from src.model.item import Item
 from src.model.box import Box
 from src.model.link import Link
@@ -11,26 +12,8 @@ class Fetcher:
     def get_all_files(self) -> list[File]:
         return [File.from_db(file) for file in self.db.fetch_all_files()]
 
-    def get_all_items(self) -> list[Item]:
-        file_dict: dict[int, File] = {file.id: file for file in self.get_all_files()}
-        return [
-            Item.from_db(item, file_dict[item.file_id])
-            for item in self.db.fetch_all_items()
-            if item.file_id in file_dict
-        ]
-
-    def get_all_boxes(self) -> list[Box]:
-        item_dict: dict[int, Item] = {item.id: item for item in self.get_all_items()}
-        return [
-            Box.from_db(box, item_dict[box.item_id])
-            for box in self.db.fetch_all_boxes()
-            if box.item_id in item_dict
-        ]
-
-    def get_all_links(self) -> list[Link]:
-        box_dict: dict[int, Box] = {box.id: box for box in self.get_all_boxes()}
-        return [
-            Link.from_db(link, box_dict[link.box_id])
-            for link in self.db.fetch_all_links()
-            if link.box_id in box_dict
-        ]
+    def get_file(self, filename: str) -> AnnotatedFile:
+        box_id_to_link: dict[int, list[Link]] = Link.get_box_id_to_link_list(self.db.fetch_file_links(filename))
+        item_id_to_box: dict[int, list[Box]] = Box.get_item_id_to_box_list(self.db.fetch_file_boxes(filename), box_id_to_link)
+        item_list: list[Item] = Item.get_list(self.db.fetch_file_items(filename), item_id_to_box)
+        return AnnotatedFile.from_db(self.db.fetch_file(filename), item_list)

--- a/src/db/db.py
+++ b/src/db/db.py
@@ -20,6 +20,18 @@ class DB:
             ).fetchall()
         return [File(**file._asdict()) for file in results]
 
+    def fetch_file(self, name: str) -> Optional[File]:
+        with self.engine.connect() as con:
+            result = con.execute(
+                sa.text('SELECT '
+                        'file.id, '
+                        'file.name, '
+                        'file.created_at, '
+                        'file.updated_at FROM files file WHERE file.name = :name'),
+                {'name': name}
+            ).fetchone()
+        return File(**result._asdict()) if result is not None else None
+
     def insert_file(self, name: str) -> int:
         with self.engine.connect() as con:
             id = con.execute(
@@ -37,19 +49,6 @@ class DB:
             ).first()
             con.commit()
         return maybeId[0] if maybeId is not None else None
-
-    def fetch_all_items(self) -> list[Item]:
-        with self.engine.connect() as con:
-            results = con.execute(
-                sa.text('SELECT '
-                        'item.id, '
-                        'item.file_id, '
-                        'item.x, '
-                        'item.y, '
-                        'item.created_at, '
-                        'item.updated_at FROM items item')
-            ).fetchall()
-        return [Item(**item._asdict()) for item in results]
 
     def insert_item(self, file_id: int, x: int, y: int) -> int:
         with self.engine.connect() as con:
@@ -82,21 +81,6 @@ class DB:
                         'WHERE file.name = :filename'), {'filename': filename}
             )
         return [Item(**item._asdict()) for item in result.fetchall()]
-
-    def fetch_all_boxes(self) -> list[Box]:
-        with self.engine.connect() as con:
-            results = con.execute(
-                sa.text('SELECT '
-                        'box.id, '
-                        'box.item_id, '
-                        'box.left, '
-                        'box.top, '
-                        'box.width, '
-                        'box.height, '
-                        'box.created_at, '
-                        'box.updated_at FROM boxes box')
-            ).fetchall()
-        return [Box(**box._asdict()) for box in results]
 
     def insert_box(self, item_id: int, left: int, top: int, width: int, height: int) -> int:
         with self.engine.connect() as con:
@@ -134,19 +118,6 @@ class DB:
                         'WHERE file.name = :filename'), {'filename': filename}
             )
         return [Box(**box._asdict()) for box in result.fetchall()]
-
-    def fetch_all_links(self) -> list[Link]:
-        with self.engine.connect() as con:
-            results = con.execute(
-                sa.text('SELECT '
-                        'link.id, '
-                        'link.box_id, '
-                        'link.link, '
-                        'link.confirmed, '
-                        'link.created_at, '
-                        'link.updated_at FROM links link')
-            ).fetchall()
-        return [Link(**link._asdict()) for link in results]
 
     def insert_link(self, box_id: int, link: str, confirmed: bool | None = None) -> int:
         with self.engine.connect() as con:

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from builder import api_builder
-from flask import Flask
+from flask import Flask, request
 from flask_cors import CORS
 from util.config import Config
 
@@ -9,25 +9,19 @@ CORS(app)
 
 api = api_builder.build()
 
-@app.route('/files/')
+@app.route('/files/', methods=['GET'])
 @config.api_check
 def files() -> list[dict]:
    return [file.to_dict() for file in api.get_all_files()]
 
-@app.route('/items/')
+@app.route('/file/', methods=['GET'])
 @config.api_check
-def items() -> list[dict]:
-   return [item.to_dict() for item in api.get_all_items()]
-
-@app.route('/boxes/')
-@config.api_check
-def boxes() -> list[dict]:
-   return [box.to_dict() for box in api.get_all_boxes()]
-
-@app.route('/links/')
-@config.api_check
-def links() -> list[dict]:
-   return [link.to_dict() for link in api.get_all_links()]
+def file() -> dict:
+   filename = request.args.get('filename')
+   if filename is not None:
+      return api.get_file(filename).to_dict()
+   else:
+      raise Exception('Must provide ?filename=<filename> for file request')
 
 if __name__ == '__main__':
    app.run(debug = True)

--- a/src/model/file.py
+++ b/src/model/file.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from src.db.model.file import File as DBFile
+from .item import Item
 
 class File(BaseModel):
     id: int
@@ -17,4 +18,24 @@ class File(BaseModel):
         return File(**{
             'id': file.id,
             'name': file.name
+        })
+
+class AnnotatedFile(BaseModel):
+    id: int
+    name: str
+    items: list[Item]
+
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'name': self.name,
+            'items': [item.to_dict() for item in self.items]
+        }
+
+    @staticmethod
+    def from_db(file: DBFile, items: list[Item]) -> AnnotatedFile:
+        return AnnotatedFile(**{
+            'id': file.id,
+            'name': file.name,
+            'items': items
         })

--- a/src/model/item.py
+++ b/src/model/item.py
@@ -1,27 +1,31 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from src.db.model.item import Item as DBItem
-from src.model.file import File
+from .box import Box
 
 class Item(BaseModel):
     id: int
-    file: File
     x: int
     y: int
+    boxes: list[Box]
 
     def to_dict(self) -> dict:
         return {
             'id': self.id,
-            'file': self.file.to_dict(),
             'x': self.x,
-            'y': self.y
+            'y': self.y,
+            'boxes': [box.to_dict() for box in self.boxes]
         }
 
     @staticmethod
-    def from_db(item: DBItem, file: File) -> Item:
+    def from_db(item: DBItem, boxes: list[Box]) -> Item:
         return Item(**{
             'id': item.id,
-            'file': file,
             'x': item.x,
-            'y': item.y
+            'y': item.y,
+            'boxes': boxes
         })
+
+    @staticmethod
+    def get_list(items: list[DBItem], item_id_to_box: dict[int, list[Box]]) -> list[Item]:
+        return [Item.from_db(item, item_id_to_box.get(item.id, [])) for item in items]

--- a/src/model/link.py
+++ b/src/model/link.py
@@ -1,27 +1,32 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from src.db.model.link import Link as DBLink
-from src.model.box import Box
 
 class Link(BaseModel):
     id: int
-    box: Box
     link: str
     confirmed: bool
 
     def to_dict(self) -> dict:
         return {
             'id': self.id,
-            'box': self.box.to_dict(),
             'link': self.link,
             'confirmed': self.confirmed
         }
 
     @staticmethod
-    def from_db(link: DBLink, box: Box) -> Link:
+    def from_db(link: DBLink) -> Link:
         return Link(**{
             'id': link.id,
-            'box': box,
             'link': link.link,
             'confirmed': link.confirmed
         })
+
+    @staticmethod
+    def get_box_id_to_link_list(links: list[DBLink]) -> dict[int, list[Link]]:
+        box_id_to_link_list: dict[int, list[Link]] = {}
+        for link in links:
+            if link.box_id not in box_id_to_link_list:
+                box_id_to_link_list[link.box_id] = []
+            box_id_to_link_list[link.box_id].append(Link.from_db(link))
+        return box_id_to_link_list


### PR DESCRIPTION
The endpoints for looking at all boxes, items, or links were for testing but are useless once many files are added.

This replaces that with the more useful class which is a single file with all items, boxes, and links attached and nested.